### PR TITLE
add global variable to configure datasets directory

### DIFF
--- a/neural/neuraldatasets.pas
+++ b/neural/neuraldatasets.pas
@@ -115,6 +115,9 @@ const
     'cat'    // used to be truck
   );
 
+var
+  directory: string = ''; // path to the dataset
+
 {$IFDEF FPC}
 type
 
@@ -925,6 +928,7 @@ var
   globalMin2, globalMax2: TNeuralFloat;
 
 begin
+  filename := directory + fileName;
   Write('Loading 10K images from file "'+fileName+'" ...');
   AssignFile(cifarFile, fileName);
   Reset(cifarFile);
@@ -988,6 +992,7 @@ var
   cifarFile: TCifar100File;
   AuxVolume: TNNetVolume;
 begin
+  filename := directory + fileName;
   if Verbose then Write('Loading images from CIFAR-100 file "'+fileName+'" ...');
   AssignFile(cifarFile, fileName);
   Reset(cifarFile);


### PR DESCRIPTION
this allows to load CIFAR10 & CIFAR100 datasets from the arbitrary location

by default, directory initialized as empty string, so this should not affects on the existing logic

usage:

`
...
uses neuraldatasets; //usual import
//initialization
neuraldatasets.directory := '..\\..\Data\cifar-10-batches-bin\'; // path to CIFAR-10* //including trailing path delimiter 
 


 ` 