### PR TITLE
Ignore the bin subdirectory of repo for GIT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ experiments
 opencl
 libs
 readme.txt
+/bin/


### PR DESCRIPTION
The bin subdirectory is filled with compilation outputs, like bin/x86_64-linux/bin/OnlyOneNeuronOrOperation  . I'd suggest to add it to `.gitignore`, so that `git status` remains clean after compilations.